### PR TITLE
Use correct event name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ class UnixStream {
       fs.unlinkSync(this.socketPath)
     } catch (err) {}
     const server = net.createServer(onSocket)
-    stream.on('finish', () => {
+    stream.on('close', () => {
       server.close()
     })
     server.listen(this.socketPath)


### PR DESCRIPTION
I was using this code in a command-line script and I was wondering why my process never exited. It turns out that the server was never being closed, because the code was listening for the wrong event.